### PR TITLE
WIP: Cadence Style Guide

### DIFF
--- a/cadence-style-guide.md
+++ b/cadence-style-guide.md
@@ -1,0 +1,65 @@
+# Cadence <- Style Guide
+## Table of contents
+1. [Identation](#identation)
+1. [Line length](#line-length)
+1. [Comments](#comments)
+1. [Whitespace between code lines](#whitespace-between-code-lines)
+1. [Declaring variables and constants](#whitespace-between-code-lines)
+1. [Bracket spaces](#bracket-spaces)
+1. [Panic messages](#panic-messages)
+1. [Naming and capitalization](#naming-and-capitalization)
+## Identation
+Use 4 spaces per indentation level.
+Prefer spaces over tabs as indentation method, mixing them should be avoided.
+## Line length
+A line lenght of 80 characters is recomended for Cadence. This could be particurally challenging when facing capability-related lines, for instance:
+```cadence
+letResourceRef = account.getCapability(ContractName.SomePathName).borrow<&SomeResource{ContractName.InterfaceName}>()
+```
+This generic line of code that could be found in a pretty similar way in lots of transactions that need to borrow a reference to a certain object from a capability it's 118 characters long by its own without any identation. Keeping this lines readable should be a main objective of any Cadence developer. There are some simple patterns that could be observed in order to accomplish this:
++ Prefer allways to break the line before the borrow call.
+```cadence
+letResourceRef = account.getCapability(ContractName.SomePathName)
+                  .borrow<&SomeResource{ContractName.InterfaceName}>()
+```
++ If identation or a long path name makes the "getCapability" line go further than 80 characters an additional line break can be included
+```cadence
+letResourceRef = account
+                  .getCapability(ContractName.SomeAbsurdlyLongForSomeReasonPathName)
+                  .borrow<&SomeResource{ContractName.InterfaceName}>()
+```
+Keep allways those concatenated function calls idented from the object they are being called from.
+## Comments
+Comments are a vital part of smart contracts, allowing users to easily understand what they are getting involve with. 
+### High level documentation at the begining of files (contracts, transactions and scripts)
+Top Level comments and comments for types, fields, events, and functions should use `///` (three slashes) because there is a cadence docs generating tool that picks up three slash comments to auto-generate docs.
+### Commenting functions
+Functions should be commented with a:
+  * Description
+  * Parameter descriptions (unless it is obvious)
+  * Return value descriptions (unless it is obvious)
+Regular comments within functions should only use two slashes (`//`)
+## Whitespace between code lines
+## Declaring variables and constants
+## Bracket spaces
+## Panic messages
+## Naming and capitalization
+### Contracts
+Contract and contract interfaces names should allways follow PascalCase, for instance:
+```cadence
+pub contract ExampleToken
+```
+### Fields
+```cadence
+pub var totalSupply
+```
+```cadence
+pub var VaultStoragePath
+```
+// Different rule for regular fields than for path fields?
+### Functions
+Functions names should allways follow camelCase, for instance:
+```cadence
+pub fun mintTokens
+```
+### Paths

--- a/cadence-style-guide.md
+++ b/cadence-style-guide.md
@@ -1,6 +1,6 @@
-# Cadence <- Style Guide
+# Cadence Style Guide
 ## Table of contents
-1. [Identation](#identation)
+1. [Indentation](#indentation)
 1. [Line length](#line-length)
 1. [Comments](#comments)
 1. [Whitespace between code lines](#whitespace-between-code-lines)
@@ -8,29 +8,29 @@
 1. [Bracket spaces](#bracket-spaces)
 1. [Panic messages](#panic-messages)
 1. [Naming and capitalization](#naming-and-capitalization)
-## Identation
+## Indentation
 Use 4 spaces per indentation level.
 Prefer spaces over tabs as indentation method, mixing them should be avoided.
 ## Line length
-A line lenght of 80 characters is recomended for Cadence. This could be particurally challenging when facing capability-related lines, for instance:
+A line length of 80 characters is recommended for Cadence. This could be particularly challenging when writing capability-related lines, for instance:
 ```cadence
 letResourceRef = account.getCapability(ContractName.SomePathName).borrow<&SomeResource{ContractName.InterfaceName}>()
 ```
-This generic line of code that could be found in a pretty similar way in lots of transactions that need to borrow a reference to a certain object from a capability it's 118 characters long by its own without any identation. Keeping this lines readable should be a main objective of any Cadence developer. There are some simple patterns that could be observed in order to accomplish this:
-+ Prefer allways to break the line before the borrow call.
+This generic line of code that can be found in many transactions that need to borrow a reference to a certain object from a capability is 118 characters long by its own without any indentation. Keeping this line readable should be an objective of any Cadence developer. There are some simple patterns that could be observed in order to accomplish this:
++ Prefer to always break the line before the `borrow` call.
 ```cadence
 letResourceRef = account.getCapability(ContractName.SomePathName)
                   .borrow<&SomeResource{ContractName.InterfaceName}>()
 ```
-+ If identation or a long path name makes the "getCapability" line go further than 80 characters an additional line break can be included
++ If indentation or a long path name makes the "getCapability" line go further than 80 characters an additional line break can be included
 ```cadence
 letResourceRef = account
                   .getCapability(ContractName.SomeAbsurdlyLongForSomeReasonPathName)
                   .borrow<&SomeResource{ContractName.InterfaceName}>()
 ```
-Keep allways those concatenated function calls idented from the object they are being called from.
+Always keep those concatenated function calls indented from the object they are being called from.
 ## Comments
-Comments are a vital part of smart contracts, allowing users to easily understand what they are getting involve with. 
+Comments are a vital part of smart contracts, allowing users to easily understand what they are getting involved with. 
 ### High level documentation at the begining of files (contracts, transactions and scripts)
 Top Level comments and comments for types, fields, events, and functions should use `///` (three slashes) because there is a cadence docs generating tool that picks up three slash comments to auto-generate docs.
 ### Commenting functions
@@ -45,7 +45,7 @@ Regular comments within functions should only use two slashes (`//`)
 ## Panic messages
 ## Naming and capitalization
 ### Contracts
-Contract and contract interfaces names should allways follow PascalCase, for instance:
+Contract and contract interfaces names should always follow PascalCase, for instance:
 ```cadence
 pub contract ExampleToken
 ```
@@ -58,7 +58,7 @@ pub var VaultStoragePath
 ```
 // Different rule for regular fields than for path fields?
 ### Functions
-Functions names should allways follow camelCase, for instance:
+Function names should always follow camelCase, for instance:
 ```cadence
 pub fun mintTokens
 ```

--- a/cadence-style-guide.md
+++ b/cadence-style-guide.md
@@ -32,13 +32,8 @@ Always keep those concatenated function calls indented from the object they are 
 ## Comments
 Comments are a vital part of smart contracts, allowing users to easily understand what they are getting involved with. 
 ### High level documentation at the begining of files (contracts, transactions and scripts)
-Top Level comments and comments for types, fields, events, and functions should use `///` (three slashes) because there is a cadence docs generating tool that picks up three slash comments to auto-generate docs.
+Top Level comments and comments for types, fields, events, and functions should use `///` (three slashes) because [the cadence docs generating tool](https://github.com/onflow/cadence/tree/master/tools/docgen) picks up three slash comments to auto-generate docs.
 ### Commenting functions
-Functions should be commented with a:
-  * Description
-  * Parameter descriptions (unless it is obvious)
-  * Return value descriptions (unless it is obvious)
-Regular comments within functions should only use two slashes (`//`)
 ## Whitespace between code lines
 ## Declaring variables and constants
 ## Bracket spaces


### PR DESCRIPTION
Closes [#2](https://github.com/onflow/cadence-style-guide/issues/2)
## Description
Developers need better guidelines for how to write clean cadence code. Define those guidelines at `docs/cadence-style-guide.md`. Early PR containing only table of contents to seek consensus about which points should the guide contain and check everyone's thoughts on conflictive aspects.

______

<!-- Complete: -->

- [x] Targeted PR against `master` branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work
- [x] Updated relevant documentation 
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Added appropriate labels 